### PR TITLE
Update to new Zed extension format.

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,0 @@
-{
-    "name": "LOG",
-    "version": "0.0.4",
-    "authors": ["evrensen467"],
-    "description": "Syntax highlighting for log files.",
-    "repository": "https://github.com/evrensen467/zed-log"
-}

--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,11 @@
+id = "log"
+name = "LOG"
+schema_version = 1
+version = "0.0.5"
+authors = ["evrensen467"]
+description = "Syntax highlighting for log files."
+repository = "https://github.com/evrensen467/zed-log"
+
+[grammars.log]
+repository = "https://github.com/Tudyx/tree-sitter-log"
+commit = "62cfe307e942af3417171243b599cc7deac5eab9"

--- a/grammars/log.toml
+++ b/grammars/log.toml
@@ -1,2 +1,0 @@
-repository = "https://github.com/Tudyx/tree-sitter-log"
-commit = "62cfe307e942af3417171243b599cc7deac5eab9"


### PR DESCRIPTION
I didn't notice that zed-log was using the old extension.json instead of extension.toml.