### PR TITLE
Use supported Zed captures for log levels

### DIFF
--- a/languages/log/highlights.scm
+++ b/languages/log/highlights.scm
@@ -1,8 +1,8 @@
 (trace) @hint
 (debug) @label
-(info) @info
-(warn) @warning
-(error) @error
+(info) @hint.info
+(warn) @constant.warning
+(error) @keyword.error
 
 (year_month_day) @keyword
 (time) @constant


### PR DESCRIPTION
## Summary

This PR fixes #6, where `INFO`, `WARN`, and `ERROR` log levels were not highlighted in some Zed themes such as One Dark.

The root cause was that the extension used these captures in `highlights.scm`:

- `@info`
- `@warning`
- `@error`

Those are not part of Zed's standard theme-supported syntax captures, so in themes that do not define them explicitly, those tokens fall back to the default foreground color.

## Change

This PR updates the log level captures to use supported captures with reliable theme fallbacks:

- `info` -> `@hint.info`
- `warn` -> `@constant.warning`
- `error` -> `@keyword.error`

`trace` and `debug` were already using compatible captures and were left unchanged.

## Result

`INFO`, `WARN`, and `ERROR` now render with consistent syntax coloring across themes instead of appearing unstyled.

<img width="243" height="206" alt="Screenshot 2026-03-17 at 04 05 01" src="https://github.com/user-attachments/assets/0cfd3a0a-e29d-4d78-a501-86633955446b" />

Closes #6
